### PR TITLE
feat: add INFTLaunchpad interface

### DIFF
--- a/src/interfaces/launchpad/INFTLaunchpad.sol
+++ b/src/interfaces/launchpad/INFTLaunchpad.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+/// @dev Interface for the NFT contract that compatible with the NFT launchpad.
+/// MUST be included ERC165 interface to support the detection of the contract's capabilities.
+interface INFTLaunchpad {
+  /**
+   * @dev Mint NFTs for the launchpad.
+   *
+   * Requirements:
+   * 	- The mintedTokenIds and mintedAmounts should have the same length.
+   *  - For ERC721 NFTs, each minted token's quantity should always be 1.
+   *  - For ERC1155 NFTs, each minted token's quantity should be actual minted amounts.
+   *	Example:
+   *  - ERC1155: If mintedTokenIds = [1, 2], then mintedAmounts = [10, 20]
+   * 	- ERC721: If mintedTokenIds = [1, 2], then mintedAmounts = [1, 1]
+   *
+   * @param to The address to mint the NFTs to.
+   * @param quantity The quantity of NFTs to mint.
+   * @param extraData The extra data for further customization.
+   * @return mintedTokenIds The token IDs of the minted NFTs.
+   * @return mintedAmounts The minted amounts according to the `mintedTokenIds`.
+   */
+  function mintLaunchpad(address to, uint256 quantity, bytes memory extraData)
+    external
+    returns (uint256[] memory mintedTokenIds, uint256[] memory mintedAmounts);
+}

--- a/src/mock/launchpad/SampleNFT1155Launchpad.sol
+++ b/src/mock/launchpad/SampleNFT1155Launchpad.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import { ERC1155 } from "../../../lib/openzeppelin-contracts/contracts/token/ERC1155/ERC1155.sol";
+import { AccessControl } from "../../../lib/openzeppelin-contracts/contracts/access/AccessControl.sol";
+import { INFTLaunchpad } from "../../interfaces/launchpad/INFTLaunchpad.sol";
+
+contract SampleNFT1155Launchpad is ERC1155, AccessControl, INFTLaunchpad {
+  bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+  constructor(address admin, address minter, string memory uri_) ERC1155(uri_) {
+    _setupRole(DEFAULT_ADMIN_ROLE, admin);
+    _setupRole(MINTER_ROLE, minter);
+  }
+
+  /// @dev Mint NFTs for the launchpad.
+  function mintLaunchpad(address to, uint256 quantity, bytes memory /* extraData */ )
+    external
+    onlyRole(MINTER_ROLE)
+    returns (uint256[] memory tokenIds, uint256[] memory amounts)
+  {
+    _mint(to, 3, quantity, "");
+
+    tokenIds = new uint256[](1);
+    amounts = new uint256[](1);
+    tokenIds[0] = 3;
+    amounts[0] = quantity;
+  }
+
+  function supportsInterface(bytes4 interfaceId) public view virtual override(ERC1155, AccessControl) returns (bool) {
+    return interfaceId == type(INFTLaunchpad).interfaceId || super.supportsInterface(interfaceId);
+  }
+}

--- a/src/mock/launchpad/SampleNFT721Launchpad.sol
+++ b/src/mock/launchpad/SampleNFT721Launchpad.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import { SampleERC721 } from "../SampleERC721.sol";
+import { ERC165 } from "../../../lib/openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
+
+import { INFTLaunchpad } from "../../interfaces/launchpad/INFTLaunchpad.sol";
+
+contract SampleNFT721Launchpad is SampleERC721, INFTLaunchpad {
+  constructor(string memory name, string memory symbol) SampleERC721(name, symbol, "sample uri") { }
+
+  /// @dev Mint NFTs for the launchpad.
+  function mintLaunchpad(address to, uint256 quantity, bytes memory /* extraData */ )
+    external
+    onlyRole(MINTER_ROLE)
+    returns (uint256[] memory tokenIds, uint256[] memory amounts)
+  {
+    tokenIds = new uint256[](quantity);
+    amounts = new uint256[](quantity);
+    for (uint256 i; i < quantity; ++i) {
+      tokenIds[i] = _mintFor(to);
+      amounts[i] = 1;
+    }
+  }
+
+  function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    return interfaceId == type(INFTLaunchpad).interfaceId || super.supportsInterface(interfaceId);
+  }
+}


### PR DESCRIPTION
### Description

Added the INFTLaunchpad interface to ensure compatibility with the launchpad. Also included are sample NFTs for both ERC721 and ERC1155 standards.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
