### PR TITLE
fix: hardhat deployment scripts

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -41,8 +41,8 @@ const config: HardhatUserConfig = {
       optimizer: {
         enabled: true,
         runs: 200,
-			},
       },
+    },
   },
   typechain: {
     outDir: './scripts/typechain-types',

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -36,13 +36,13 @@ const mainnet: NetworkUserConfig = {
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: '0.8.17',
+    version: '0.8.19',
     settings: {
       optimizer: {
         enabled: true,
         runs: 200,
+			},
       },
-    },
   },
   typechain: {
     outDir: './scripts/typechain-types',

--- a/scripts/deploy/logic/erc721-upgradeable-logic.ts
+++ b/scripts/deploy/logic/erc721-upgradeable-logic.ts
@@ -3,14 +3,14 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types';
 const deploy = async ({ getNamedAccounts, deployments, ethers }: HardhatRuntimeEnvironment) => {
   const { deploy } = deployments;
   const { deployer } = await getNamedAccounts();
-  await deploy('SampleERC721CommonUpgradeableLogic', {
-    contract: 'ERC721CommonUpgradeable',
+  await deploy('SampleERC721UpgradeableLogic', {
+    contract: 'SampleERC721Upgradeable',
     from: deployer,
     log: true,
   });
 };
 
-deploy.tags = ['SampleERC721CommonUpgradeableLogic'];
+deploy.tags = ['SampleERC721UpgradeableLogic'];
 deploy.dependencies = ['VerifyContracts'];
 
 export default deploy;

--- a/scripts/deploy/proxy-admin.ts
+++ b/scripts/deploy/proxy-admin.ts
@@ -1,12 +1,14 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import ProxyAdmin from 'hardhat-deploy/extendedArtifacts/ProxyAdmin.json';
 
 const deploy = async ({ getNamedAccounts, deployments, ethers }: HardhatRuntimeEnvironment) => {
   const { deploy } = deployments;
   const { deployer } = await getNamedAccounts();
   await deploy('ProxyAdmin', {
-    contract: 'ProxyAdmin',
+    contract: ProxyAdmin,
     from: deployer,
     log: true,
+    args: [deployer],
   });
 };
 

--- a/scripts/deploy/proxy/erc721-upgradeable-proxy.ts
+++ b/scripts/deploy/proxy/erc721-upgradeable-proxy.ts
@@ -1,25 +1,26 @@
-import { ERC721CommonUpgradeable__factory } from '../../typechain-types';
+import { SampleERC721Upgradeable__factory } from '../../typechain-types';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import TransparentUpgradeableProxy from 'hardhat-deploy/extendedArtifacts/TransparentUpgradeableProxy.json';
 
-const erc721Interface = ERC721CommonUpgradeable__factory.createInterface();
+const erc721Interface = SampleERC721Upgradeable__factory.createInterface();
 
 const deploy = async ({ getNamedAccounts, deployments, network }: HardhatRuntimeEnvironment) => {
   const { deploy } = deployments;
   const { deployer } = await getNamedAccounts();
   const proxyAdmin = await deployments.get('ProxyAdmin');
-  const logicContract = await deployments.get('SampleERC721CommonUpgradeableLogic');
+  const logicContract = await deployments.get('SampleERC721UpgradeableLogic');
 
   const data = erc721Interface.encodeFunctionData('initialize', ['SampleERC721', 'NFT', 'http://example.com/']);
 
   await deploy('SampleERC721CommonUpgradeableProxy', {
-    contract: 'TransparentUpgradeableProxy',
+    contract: TransparentUpgradeableProxy,
     from: deployer,
     log: true,
-    args: [logicContract.address, proxyAdmin, data],
+    args: [logicContract.address, proxyAdmin.address, data],
   });
 };
 
-deploy.tags = ['SampleERC721CommonUpgradeableProxy'];
-deploy.dependencies = ['VerifyContracts', 'ProxyAdmin', 'SampleERC721CommonUpgradeableLogic'];
+deploy.tags = ['SampleERC721UpgradeableProxy'];
+deploy.dependencies = ['VerifyContracts', 'ProxyAdmin', 'SampleERC721UpgradeableLogic'];
 
 export default deploy;

--- a/src/interfaces/launchpad/INFTLaunchpad.sol
+++ b/src/interfaces/launchpad/INFTLaunchpad.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.19;
 
 /// @dev Interface for the NFT contract that compatible with the NFT launchpad.
 /// MUST be included ERC165 interface to support the detection of the contract's capabilities.

--- a/src/mock/launchpad/SampleNFT1155Launchpad.sol
+++ b/src/mock/launchpad/SampleNFT1155Launchpad.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.19;
 
 import { ERC1155 } from "../../../lib/openzeppelin-contracts/contracts/token/ERC1155/ERC1155.sol";
 import { AccessControl } from "../../../lib/openzeppelin-contracts/contracts/access/AccessControl.sol";

--- a/src/mock/launchpad/SampleNFT721Launchpad.sol
+++ b/src/mock/launchpad/SampleNFT721Launchpad.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.19;
 
 import { SampleERC721 } from "../SampleERC721.sol";
 import { ERC165 } from "../../../lib/openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";

--- a/src/upgradeable/ERC721CommonUpgradeable.sol
+++ b/src/upgradeable/ERC721CommonUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.19;
 
 import { ERC721Upgradeable } from
   "../../lib/openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";

--- a/src/upgradeable/ERC721PresetMinterPauserAutoIdCustomizedUpgradeable.sol
+++ b/src/upgradeable/ERC721PresetMinterPauserAutoIdCustomizedUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.19;
 
 import { ERC721Upgradeable } from
   "../../lib/openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";

--- a/src/upgradeable/refs/ERC721NonceUpgradeable.sol
+++ b/src/upgradeable/refs/ERC721NonceUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.19;
 
 import { ERC721Upgradeable } from
   "../../../lib/openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";

--- a/test/foundry/SampleERC721Upgradeable.t.sol
+++ b/test/foundry/SampleERC721Upgradeable.t.sol
@@ -30,7 +30,7 @@ contract SampleERC721Upgradeable_Test is Test {
   string public constant SYMBOL = "NFT";
   string public constant BASE_URI = "http://example.com/";
 
-	address internal _proxyAdmin;
+  address internal _proxyAdmin;
   // token test
   ERC721CommonUpgradeable internal _testToken;
 

--- a/test/foundry/SampleERC721Upgradeable.t.sol
+++ b/test/foundry/SampleERC721Upgradeable.t.sol
@@ -6,6 +6,7 @@ import { ERC721NonceUpgradeable } from "src/upgradeable/refs/ERC721NonceUpgradea
 import { Strings } from "../../lib/openzeppelin-contracts/contracts/utils/Strings.sol";
 import { TransparentUpgradeableProxy } from
   "../../lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ProxyAdmin } from "../../lib/openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
 import { IERC721Upgradeable } from "lib/openzeppelin-contracts-upgradeable/contracts/interfaces/IERC721Upgradeable.sol";
 import { IAccessControlEnumerableUpgradeable } from
   "lib/openzeppelin-contracts-upgradeable/contracts/access/IAccessControlEnumerableUpgradeable.sol";
@@ -29,12 +30,12 @@ contract SampleERC721Upgradeable_Test is Test {
   string public constant SYMBOL = "NFT";
   string public constant BASE_URI = "http://example.com/";
 
-  address _proxyAdmin;
+	address internal _proxyAdmin;
   // token test
   ERC721CommonUpgradeable internal _testToken;
 
   function setUp() public virtual {
-    _proxyAdmin = makeAddr("proxy-admin");
+    _proxyAdmin = address(new ProxyAdmin());
 
     bytes memory initializeData =
       abi.encodeCall(ERC721PresetMinterPauserAutoIdCustomizedUpgradeable.initialize, (NAME, SYMBOL, BASE_URI));


### PR DESCRIPTION
### Description
What changes?
- Downgrade solidity version to 0.8.19 (instead of 0.8.22) because our EVM version (testnet: london,  mainnet: istanbul) does not support PUSH0 opcode. 
- Fix script deploy ProxyAdmin, using DefaultProxyAdmin artifact of hardhat-deploy. 
- 
### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
